### PR TITLE
 使用多一些的内存代价来优化超大文件(G为单位)流式diff时的速度(对几百兆的小文件几乎无效)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **HDiffPatch**
 ================
-Version 2.1.1   
+Version 2.1.2   
 byte data Diff & Patch  C\C++ library.  
 
 ---

--- a/libHDiffPatch/HDiff/diff.cpp
+++ b/libHDiffPatch/HDiff/diff.cpp
@@ -332,7 +332,7 @@ static void extend_cover(TDiffData& diff){
 }
 
     template<class _TCover,class _TInt>
-    static void check_cover_safe(const _TCover& cover,_TInt lastNewEnd,_TInt newSize,_TInt oldSize){
+    static void assert_cover_safe(const _TCover& cover,_TInt lastNewEnd,_TInt newSize,_TInt oldSize){
         if (!(cover.length>0)) throw cover;
         if (!(cover.newPos>=lastNewEnd)) throw cover;
         if (!(cover.newPos<newSize)) throw cover;
@@ -358,8 +358,8 @@ static void sub_cover(TDiffData& diff){
     
     TInt lastNewEnd=0;
     for (TInt i=0;i<(TInt)covers.size();++i){
-        check_cover_safe(covers[i],lastNewEnd,
-                         diff.newData_end-diff.newData,diff.oldData_end-diff.oldData);
+        assert_cover_safe(covers[i],lastNewEnd,
+                          diff.newData_end-diff.newData,diff.oldData_end-diff.oldData);
         const TInt newPos=covers[i].newPos;
         if (newPos>lastNewEnd)
             pushBack(diff.newDataDiff,newData+lastNewEnd,newData+newPos);
@@ -672,7 +672,7 @@ static void getCovers_stream(const hpatch_TStreamInput*  newData,
         hpatch_StreamPos_t lastNewEnd=0;
         for (size_t i=0;i<out_covers.coverCount();++i){
             out_covers.covers(i,&cover);
-            check_cover_safe(cover,lastNewEnd,newData->streamSize,oldData->streamSize);
+            assert_cover_safe(cover,lastNewEnd,newData->streamSize,oldData->streamSize);
             lastNewEnd=cover.newPos+cover.length;
         }
     }

--- a/libHDiffPatch/HDiff/diff.h
+++ b/libHDiffPatch/HDiff/diff.h
@@ -123,8 +123,8 @@ typedef struct hdiff_TStreamCompress{
 //diff by stream:
 //  can control memory requires and run speed by different kMatchBlockSize value,
 //      but out_diff size is larger than create_compressed_diff()
-//  recommended used in limited environment
-//  kMatchBlockSize: in [1<<3..1<<24], recommended (1<<4)--(1<<12)
+//  recommended used in limited environment or support large file
+//  kMatchBlockSize: in [1<<1..1<<24], recommended (1<<3)--(1<<14)
 //    if kMatchBlockSize decrease then out_diff size decrease, but slower and memory requires more
 //  NOTICE: out_diff->write()'s writeToPos may be back to update headData!
 //  throw std::runtime_error when I/O error,etc.

--- a/libHDiffPatch/HDiff/private_diff/compress_detect.h
+++ b/libHDiffPatch/HDiff/private_diff/compress_detect.h
@@ -40,7 +40,7 @@ typedef unsigned __int32  uint32_t;
 #endif
 
 template<class _UInt>
-static int _getUIntCost(_UInt v){
+static unsigned int _getUIntCost(_UInt v){
     if ((sizeof(_UInt)<8)||((v>>28)>>28)==0) {
         int cost=1;
         _UInt t;
@@ -54,7 +54,7 @@ static int _getUIntCost(_UInt v){
 }
 
 template<class _Int,class _UInt>
-inline static int _getIntCost(_Int v){
+inline static unsigned _getIntCost(_Int v){
     return _getUIntCost((_UInt)(2*((v>=0)?(_UInt)v:(_UInt)(-v))));
 }
 

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.c
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.c
@@ -130,6 +130,23 @@
     }
 #endif
 
+#define  _adler_combine(uint_t,half_bit,mod,border,BASE,\
+                        adler1,adler2,len2){ \
+    const uint_t kMask=((uint_t)1<<half_bit)-1; \
+    uint_t rem= mod(len2);      \
+    uint_t sum1 = adler1 & kMask;   \
+    uint_t sum2 = rem * sum1;   \
+    sum1 += (adler2 & kMask) + BASE - 1;    \
+    sum2 += ((adler1 >> half_bit) & kMask)  \
+          + ((adler2 >> half_bit) & kMask) + BASE - rem; \
+    border(sum1); \
+    border(sum1); \
+    border(sum2); \
+    border(sum2); \
+    border(sum2); \
+    return sum1 | (sum2 << half_bit); \
+}
+
 //limit: all result in uint32_t
 //blockSize*255+(B-1)<2^32 && [0..B-1]+[0..B-1]+(blockSize*255+(B-1))/B*B<2^32
 // => blockSize*255<=(2^32-1)-(B-1) && (B-1)+(B-1)+(blockSize*255+(B-1))/B*B<=(2^32-1)
@@ -168,6 +185,9 @@ uint32_t adler32_roll_step(uint32_t adler,uint32_t blockSize,uint32_t kBlockSize
                      adler,blockSize,kBlockSizeBM, out_data,in_data)
 #endif
 
+uint32_t adler32_combine(uint32_t adler1,uint32_t adler2,size_t len2)
+    _adler_combine(uint32_t,16,_adler32_mod,_adler32_to_border,_adler32_BASE,
+                   adler1,adler2,len2)
 
 #ifdef _IS_NEED_ADLER64
 uint64_t adler64_append(uint64_t adler,const adler_data_t* pdata,size_t n)
@@ -184,6 +204,10 @@ uint64_t adler64_roll_step(uint64_t adler,uint64_t blockSize,uint64_t kBlockSize
     _adler_roll_step(uint64_t,32,_adler64_mod,_adler64_to_border,_adler64_BASE,
                      adler,blockSize,kBlockSizeBM, out_data,in_data)
 #endif
+
+uint64_t adler64_combine(uint64_t adler1,uint64_t adler2,uint64_t len2)
+    _adler_combine(uint64_t,32,_adler64_mod,_adler64_to_border,_adler64_BASE,
+                   adler1,adler2,len2)
 
 #endif //_IS_NEED_ADLER64
 

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.c
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.c
@@ -38,7 +38,8 @@
 #else
 #   define _adler32_BASE 65521 //largest prime that is less than 2^32
 //# define _adler32_to_border(v) { if ((v) >= _adler32_BASE) (v) -= _adler32_BASE; }
-#   define _adler32_to_border(v) { (v) -= _adler32_BASE & (uint32_t)( ((_adler32_BASE-1)-(int32_t)(v))>>31 ); }
+#   define _adler32_to_border(v) { (v) -= _adler32_BASE & (uint32_t)( \
+                                          ((int32_t)(_adler32_BASE-1)-(int32_t)(v))>>31 ); }
 #   define _adler32_mod(v)       ((v)%_adler32_BASE)
 #endif
 
@@ -51,7 +52,8 @@
 #else
 #   define _adler64_BASE 0xFFFFFFFBull
 //# define _adler64_to_border(v) { if ((v) >= _adler64_BASE) (v) -= _adler64_BASE; }
-#   define _adler64_to_border(v) { (v) -= _adler64_BASE & (uint64_t)( ((_adler64_BASE-1)-(int64_t)(v))>>63 ); }
+#   define _adler64_to_border(v) { (v) -= _adler64_BASE & (uint64_t)( \
+                                          ((int64_t)(_adler64_BASE-1)-(int64_t)(v))>>63 ); }
 #   define _adler64_mod(v)       ((v)%_adler64_BASE)
 #endif
 #endif
@@ -67,6 +69,13 @@
     _adler_add1(adler,sum,pdata[i+2]); \
     _adler_add1(adler,sum,pdata[i+3]); \
 }
+
+
+#ifdef _IS_USE_ADLER_FAST_BASE
+#   define _border_twice(border,v) border(v)
+#else
+#   define _border_twice(border,v) { border(v); border(v); }
+#endif
 
 //limit: 255*n*(n+1)/2 + (n+1)(B-1) <= 2^32-1
 // => max(n)=5552
@@ -122,29 +131,26 @@
         adler&=(((uint_t)1<<half_bit)-1); \
         /*  [0..B-1] + [0..255] + B - [0..255]   =>  [0+0+B-255..B-1+255+B-0]*/ \
         adler += in_data +(uint_t)(BASE - out_data);/* => [B-255..B*2-1+255] */ \
-        border(adler); /* [0..B-1+255] */   \
-        border(adler); /* [0..B-1] */       \
+        _border_twice(adler);             \
         /*  limit by adler?_roll_blockSizeBM() and adler?_roll_kMaxBlockSize */ \
         sum = mod(sum + adler + kBlockSizeBM - blockSize*out_data); \
-        return adler | (sum<<half_bit); \
+        return adler | (sum<<half_bit);   \
     }
 #endif
 
-#define  _adler_combine(uint_t,half_bit,mod,border,BASE,\
-                        adler1,adler2,len2){ \
+#define  _adler_roll_combine(uint_t,half_bit,mod,border,        \
+                             adler_left,adler_right,len_right){ \
     const uint_t kMask=((uint_t)1<<half_bit)-1; \
-    uint_t rem= mod(len2);      \
-    uint_t sum1 = adler1 & kMask;   \
-    uint_t sum2 = rem * sum1;   \
-    sum1 += (adler2 & kMask) + BASE - 1;    \
-    sum2 += ((adler1 >> half_bit) & kMask)  \
-          + ((adler2 >> half_bit) & kMask) + BASE - rem; \
-    border(sum1); \
-    border(sum1); \
-    border(sum2); \
-    border(sum2); \
-    border(sum2); \
-    return sum1 | (sum2 << half_bit); \
+    uint_t rem= mod(len_right);       \
+    uint_t adler= adler_left & kMask; \
+    uint_t sum  = rem * adler;        \
+    adler+= (adler_right & kMask) ;   \
+    sum   = mod(sum);                 \
+    sum  += (adler_left>>half_bit)    \
+          + (adler_right>>half_bit);  \
+    border(adler);                    \
+    _border_twice(border,sum);        \
+    return adler | (sum<<half_bit);   \
 }
 
 //limit: all result in uint32_t
@@ -185,9 +191,9 @@ uint32_t adler32_roll_step(uint32_t adler,uint32_t blockSize,uint32_t kBlockSize
                      adler,blockSize,kBlockSizeBM, out_data,in_data)
 #endif
 
-uint32_t adler32_combine(uint32_t adler1,uint32_t adler2,size_t len2)
-    _adler_combine(uint32_t,16,_adler32_mod,_adler32_to_border,_adler32_BASE,
-                   adler1,adler2,len2)
+uint32_t adler32_roll_combine(uint32_t adler_left,uint32_t adler_right,size_t len_right)
+    _adler_roll_combine(uint32_t,16,_adler32_mod,_adler32_to_border,
+                        adler_left,adler_right,len_right)
 
 #ifdef _IS_NEED_ADLER64
 uint64_t adler64_append(uint64_t adler,const adler_data_t* pdata,size_t n)
@@ -205,9 +211,9 @@ uint64_t adler64_roll_step(uint64_t adler,uint64_t blockSize,uint64_t kBlockSize
                      adler,blockSize,kBlockSizeBM, out_data,in_data)
 #endif
 
-uint64_t adler64_combine(uint64_t adler1,uint64_t adler2,uint64_t len2)
-    _adler_combine(uint64_t,32,_adler64_mod,_adler64_to_border,_adler64_BASE,
-                   adler1,adler2,len2)
+uint64_t adler64_roll_combine(uint64_t adler_left,uint64_t adler_right,uint64_t len_right)
+    _adler_roll_combine(uint64_t,32,_adler64_mod,_adler64_to_border,
+                        adler_left,adler_right,len_right)
 
 #endif //_IS_NEED_ADLER64
 

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
@@ -53,6 +53,7 @@ extern "C" {
 #   define adler_roll_kBlockSizeBM      adler64_roll_kBlockSizeBM
 #   define adler_roll_start             adler64_roll_start
 #   define adler_roll_step              adler64_roll_step
+#   define adler_combine                adler64_combine
 #else
 #   define adler_uint_t                 uint32_t
 #   define adler_append                 adler32_append
@@ -60,6 +61,7 @@ extern "C" {
 #   define adler_roll_kBlockSizeBM      adler32_roll_kBlockSizeBM
 #   define adler_roll_start             adler32_roll_start
 #   define adler_roll_step              adler32_roll_step
+#   define adler_combine                adler32_combine
 #endif
     
 #ifdef _MSC_VER
@@ -115,6 +117,8 @@ uint32_t adler32_roll_step(uint32_t adler,uint32_t blockSize,uint32_t kBlockSize
                            adler_data_t out_data,adler_data_t in_data);
 #endif
     
+uint32_t adler32_combine(uint32_t adler1,uint32_t adler2,size_t len2);
+
 
 #ifdef _IS_NEED_ADLER64
     
@@ -133,6 +137,8 @@ uint64_t adler64_roll_step(uint64_t adler,uint64_t blockSize,uint64_t kBlockSize
 uint64_t adler64_roll_step(uint64_t adler,uint64_t blockSize,uint64_t kBlockSizeBM,
                            adler_data_t out_data,adler_data_t in_data);
 #endif
+    
+uint64_t adler64_combine(uint64_t adler1,uint64_t adler2,uint64_t len2);
 
 #endif //_IS_NEED_ADLER64
     

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
@@ -37,6 +37,18 @@
 extern "C" {
 #endif
     
+#ifndef adler_data_t
+    //adler32 adler_data_t: support uint8: roll_kMaxBlockSize==2^24+little and uint16: roll_kMaxBlockSize==2^16-2
+    //adler64 adler_data_t: support uint8\uint16\uint32 : roll_kMaxBlockSize enough large
+    //but if defined _IS_USE_ADLER_FAST_BASE then roll_kMaxBlockSize enough large (no limit)
+#   define adler_data_t unsigned char
+#endif
+    
+#define _IS_USE_ADLER_FAST_BASE //WARNING: result non-standard, optimize roll_step speed
+#define _IS_NEED_ADLER64
+#if defined(__LP64__) || defined(_WIN64) || ( __WORDSIZE==64 ) || (UINT_MAX > 0xffffffff )
+#define _IS_DEFAULT_ADLER64
+#endif
     
 #ifdef _MSC_VER
 #   if (_MSC_VER < 1300)
@@ -57,18 +69,6 @@ extern "C" {
 #endif
 #include <stdlib.h> //for size_t
     
-#ifndef adler_data_t
-    //adler32 adler_data_t: support uint8: roll_kMaxBlockSize==2^24+little and uint16: roll_kMaxBlockSize==2^16-2
-    //adler64 adler_data_t: support uint8\uint16\uint32 : roll_kMaxBlockSize enough large
-    //but if defined _IS_USE_ADLER_FAST_BASE then roll_kMaxBlockSize enough large (no limit)
-#   define adler_data_t unsigned char
-#endif
-    
-#define _IS_USE_ADLER_FAST_BASE //WARNING: result non-standard, optimize roll_step speed
-//#define _IS_NEED_ADLER64
-#if defined(__LP64__) || defined(_WIN64) || ( __WORDSIZE==64 ) || (UINT_MAX > 0xffffffff )
-    #define _IS_DEFAULT_ADLER64
-#endif
 
 #ifdef _IS_DEFAULT_ADLER64
 #   ifndef _IS_NEED_ADLER64

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
@@ -39,7 +39,9 @@ extern "C" {
     
 #define _IS_USE_ADLER_FAST_BASE //WARNING: result non-standard, optimize roll_step speed
 //#define _IS_NEED_ADLER64
-//#define _IS_DEFAULT_ADLER64
+#if defined(__LP64__) || defined(_WIN64) || ( __WORDSIZE==64 ) || (UINT_MAX > 0xffffffff )
+    #define _IS_DEFAULT_ADLER64
+#endif
 
 #ifdef _IS_DEFAULT_ADLER64
 #   ifndef _IS_NEED_ADLER64

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
@@ -37,6 +37,33 @@
 extern "C" {
 #endif
     
+    
+#ifdef _MSC_VER
+#   if (_MSC_VER < 1300)
+    typedef signed int        int32_t;
+    typedef unsigned int      uint32_t;
+#   else
+    typedef signed __int32    int32_t;
+    typedef unsigned __int32  uint32_t;
+#   endif
+#   ifdef _IS_NEED_ADLER64
+    typedef signed   __int64  int64_t;
+    typedef unsigned __int64  uint64_t;
+#   endif
+#   define __adler_inline _inline
+#else
+#   include <stdint.h> //for int32_t uint32_t int64_t uint64_t
+#   define __adler_inline inline
+#endif
+#include <stdlib.h> //for size_t
+    
+#ifndef adler_data_t
+    //adler32 adler_data_t: support uint8: roll_kMaxBlockSize==2^24+little and uint16: roll_kMaxBlockSize==2^16-2
+    //adler64 adler_data_t: support uint8\uint16\uint32 : roll_kMaxBlockSize enough large
+    //but if defined _IS_USE_ADLER_FAST_BASE then roll_kMaxBlockSize enough large (no limit)
+#   define adler_data_t unsigned char
+#endif
+    
 #define _IS_USE_ADLER_FAST_BASE //WARNING: result non-standard, optimize roll_step speed
 //#define _IS_NEED_ADLER64
 #if defined(__LP64__) || defined(_WIN64) || ( __WORDSIZE==64 ) || (UINT_MAX > 0xffffffff )
@@ -53,7 +80,7 @@ extern "C" {
 #   define adler_roll_kBlockSizeBM      adler64_roll_kBlockSizeBM
 #   define adler_roll_start             adler64_roll_start
 #   define adler_roll_step              adler64_roll_step
-#   define adler_combine                adler64_combine
+#   define adler_roll_combine           adler64_roll_combine
 #else
 #   define adler_uint_t                 uint32_t
 #   define adler_append                 adler32_append
@@ -61,34 +88,9 @@ extern "C" {
 #   define adler_roll_kBlockSizeBM      adler32_roll_kBlockSizeBM
 #   define adler_roll_start             adler32_roll_start
 #   define adler_roll_step              adler32_roll_step
-#   define adler_combine                adler32_combine
+#   define adler_roll_combine           adler32_roll_combine
 #endif
-    
-#ifdef _MSC_VER
-#   if (_MSC_VER < 1300)
-typedef signed int        int32_t;
-typedef unsigned int      uint32_t;
-#   else
-typedef signed __int32    int32_t;
-typedef unsigned __int32  uint32_t;
-#   endif
-#   ifdef _IS_NEED_ADLER64
-typedef signed   __int64  int64_t;
-typedef unsigned __int64  uint64_t;
-#   endif
-#   define __adler_inline _inline
-#else
-#   include <stdint.h> //for int32_t uint32_t int64_t uint64_t
-#   define __adler_inline inline
-#endif
-#include <stdlib.h> //for size_t
 
-#ifndef adler_data_t
-//adler32 adler_data_t: support uint8: roll_kMaxBlockSize==2^24+little and uint16: roll_kMaxBlockSize==2^16-2
-//adler64 adler_data_t: support uint8\uint16\uint32 : roll_kMaxBlockSize enough large
-//but if defined _IS_USE_ADLER_FAST_BASE then roll_kMaxBlockSize enough large (no limit)
-#define adler_data_t unsigned char
-#endif
     
 #ifdef _IS_USE_ADLER_FAST_BASE
 #   define  __private_adler_roll_step_fast(uint_t,half_bit,\
@@ -117,7 +119,7 @@ uint32_t adler32_roll_step(uint32_t adler,uint32_t blockSize,uint32_t kBlockSize
                            adler_data_t out_data,adler_data_t in_data);
 #endif
     
-uint32_t adler32_combine(uint32_t adler1,uint32_t adler2,size_t len2);
+uint32_t adler32_roll_combine(uint32_t adler_left,uint32_t adler_right,size_t len_right);
 
 
 #ifdef _IS_NEED_ADLER64
@@ -138,7 +140,7 @@ uint64_t adler64_roll_step(uint64_t adler,uint64_t blockSize,uint64_t kBlockSize
                            adler_data_t out_data,adler_data_t in_data);
 #endif
     
-uint64_t adler64_combine(uint64_t adler1,uint64_t adler2,uint64_t len2);
+uint64_t adler64_roll_combine(uint64_t adler_left,uint64_t adler_right,uint64_t len_right);
 
 #endif //_IS_NEED_ADLER64
     

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/bloom_filter.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/bloom_filter.h
@@ -95,11 +95,11 @@ private:
     size_t    m_bitSetMask;
     enum { kZoom=32 };
     static size_t getMask(size_t dataCount){
-        size_t bitCount=dataCount*kZoom;
-        if ((bitCount/kZoom)!=dataCount)
-            throw std::runtime_error("TBloomFilter::getMask() too large dataCount error!");
+        size_t bitSize=dataCount*kZoom;
+        if ((bitSize/kZoom)!=dataCount)
+            throw std::runtime_error("TBloomFilter::getMask() bitSize too large error!");
         unsigned int bit=10;
-        while ( (((size_t)1<<bit)<bitCount) && (bit<sizeof(size_t)*8-1) )
+        while ( (((size_t)1<<bit)<bitSize) && (bit<sizeof(size_t)*8-1) )
             ++bit;
         return ((size_t)1<<bit)-1;
     }

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
@@ -29,11 +29,14 @@
 #include <assert.h>
 #include <stdexcept>  //std::runtime_error
 #include <algorithm>  //std::sort,std::equal_range
+#include "../compress_detect.h" //_getUIntCost
 
 static  const size_t kMinTrustMatchedLength=16*1024;
 static  const size_t kBestReadSize=1024*256; //for sequence read
 static  const size_t kMinReadSize=1024;      //for random read
 static  const size_t kMinBackupReadSize=256; //assert(kMinBackupReadSize<kMinReadSize)
+
+static  const size_t kMinMatchBlockSize=1<<1;
 
 #define readStream(stream,pos,dst,n) { \
     if ((long)(n)!=(stream)->read((stream)->streamHandle,pos,dst,dst+(n))) \
@@ -114,13 +117,17 @@ static hpatch_StreamPos_t blockIndexToPos(size_t index,size_t kMatchBlockSize,
 
 
 TDigestMatcher::TDigestMatcher(const hpatch_TStreamInput* oldData,size_t kMatchBlockSize)
-:m_oldData(oldData),m_isUseLargeSorted(true),m_kMatchBlockSize(kMatchBlockSize),m_newCacheSize(0){
+:m_oldData(oldData),m_isUseLargeSorted(true),m_kMatchBlockSize(0),m_newCacheSize(0){
     if ((kMatchBlockSize==0)||(kMatchBlockSize>adler32_roll_kMaxBlockSize))
         throw std::runtime_error("TDataDigest() kMatchBlockSize value error.");
-    while ((m_kMatchBlockSize>1)&&(m_kMatchBlockSize>=m_oldData->streamSize))
-        m_kMatchBlockSize>>=1;
+    if (kMatchBlockSize>(oldData->streamSize+1)/2)
+        kMatchBlockSize=(size_t)((oldData->streamSize+1)/2);
+    if (kMatchBlockSize<kMinMatchBlockSize)
+        kMatchBlockSize=kMinMatchBlockSize;
+    if (oldData->streamSize<kMatchBlockSize) return;
+    m_kMatchBlockSize=kMatchBlockSize;
+    
     hpatch_StreamPos_t _blockCount=getBlockCount(m_kMatchBlockSize,m_oldData->streamSize);
-    if (m_oldData->streamSize<m_kMatchBlockSize) _blockCount=0;
     m_isUseLargeSorted=(_blockCount>=((hpatch_StreamPos_t)1<<32));
     const size_t blockCount=(size_t)_blockCount;
     if (blockCount!=_blockCount)
@@ -331,6 +338,23 @@ public:
     size_t              i;
 };
 
+    static hpatch_StreamPos_t getMatchLength(TOldStreamCache& oldStream,TNewStreamCache& newStream,
+                                             hpatch_StreamPos_t& oldPos,size_t kMatchBlockSize,
+                                             const TCover& lastCover){
+        if (oldStream.resetPos(oldPos)
+                &&(0==memcmp(oldStream.data(),newStream.data(),kMatchBlockSize))){
+            const hpatch_StreamPos_t newPos=newStream.pos();
+            size_t feq_len=oldStream.forward_equal_length(newStream);
+            if (newPos-feq_len<lastCover.newPos+lastCover.length)
+                feq_len=(size_t)(newPos-(lastCover.newPos+lastCover.length));
+            hpatch_StreamPos_t beq_len=newStream.roll_backward_equal_length(oldStream);
+            oldPos-=feq_len;
+            return feq_len+kMatchBlockSize+beq_len;
+        }else{
+            return 0;
+        }
+    }
+
 template <class TIndex>
 static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
                          const TIndex* left,const TIndex* right,
@@ -342,8 +366,20 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
     
     const TIndex* best=left;
     size_t bdigests_n=0;
+    //缩小[left best right)范围,留下最多2个(因为签名匹配并不保证一定相等,2个的话就足够了);
     if (right-left>1){
-        //缩小[left best right)范围,留下最多2个;
+        //找到lastCover附近的位置当作比较好的best默认值;
+        hpatch_StreamPos_t linkOldPos=newStream.pos()+lastCover.oldPos-lastCover.newPos;
+        hpatch_StreamPos_t _best_distance=(hpatch_StreamPos_t)1<<30;
+        for (const TIndex* it=left;it<right; ++it) {
+            hpatch_StreamPos_t oldPos=(*it)*kMatchBlockSize;
+            hpatch_StreamPos_t distance=(oldPos<linkOldPos)?(linkOldPos-oldPos):(oldPos-linkOldPos);
+            if (distance<_best_distance){
+                best=it;
+                _best_distance=distance;
+            }
+        }
+        //寻找最长的签名匹配位置;
         newStream.toBestDataLength();
         size_t bmaxn=newStream.dataLength()/kMatchBlockSize-1;
         if (bmaxn>max_bdigests_n) bmaxn=max_bdigests_n;
@@ -360,9 +396,10 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
                 best=i_range.first;
                 break;
             }else{
-                best=left;
                 left=i_range.first;
                 right=i_range.second;
+                if ((best<left)||(best>=right))
+                    best=left;
             }
         }
     }
@@ -377,22 +414,17 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
     for (const TIndex* cur_pi=best; cur_pi!=0; ) {
         const hpatch_StreamPos_t oldPos=blockIndexToPos(*cur_pi,kMatchBlockSize,
                                                         oldStream.streamSize());
-        if ((oldStream.resetPos(oldPos))&&(0==memcmp(oldStream.data(),newStream.data(),
-                                                     kMatchBlockSize))){
-            size_t feq_len=oldStream.forward_equal_length(newStream);
-            if (newPos-feq_len<lastCover.newPos+lastCover.length)
-                feq_len=(size_t)(newPos-(lastCover.newPos+lastCover.length));
-            hpatch_StreamPos_t beq_len=newStream.roll_backward_equal_length(oldStream);
-            hpatch_StreamPos_t curEqLen=feq_len+kMatchBlockSize+beq_len;
-            if (curEqLen>bestLen){
-                isMatched=true;
-                bestLen=curEqLen;
-                out_curCover->length=curEqLen;
-                out_curCover->oldPos=oldPos-feq_len;
-                out_curCover->newPos=newPos-feq_len;
-                if (curEqLen>=bdigests_n*kMatchBlockSize)
-                    break;//matched best
-            }
+        hpatch_StreamPos_t matchedOldPos=oldPos;
+        hpatch_StreamPos_t curEqLen=getMatchLength(oldStream,newStream,
+                                                   matchedOldPos,kMatchBlockSize,lastCover);
+        if (curEqLen>bestLen){
+            isMatched=true;
+            bestLen=curEqLen;
+            out_curCover->length=curEqLen;
+            out_curCover->oldPos=matchedOldPos;
+            out_curCover->newPos=newPos-(oldPos-matchedOldPos);
+            if (curEqLen>=bdigests_n*kMatchBlockSize)
+                break;//matched best
         }
         //next cur_pi
         if (left!=0){
@@ -410,16 +442,18 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
     return isMatched;
 }
 
-
-static bool is_same_data(const unsigned char* s,size_t n){
-    if (n==0) return true;
-    unsigned char d=s[0];
-    for (size_t i=1; i<n; ++i) {
-        if(s[i]!=d)
-            return false;
-    }
-    return true;
+static const size_t getOldPosCost(hpatch_StreamPos_t oldPos,const TCover& lastCover){
+    hpatch_StreamPos_t oldPosEnd=lastCover.oldPos+lastCover.length;
+    hpatch_StreamPos_t dis=(oldPos>=oldPosEnd)?(oldPos-oldPosEnd):(oldPosEnd-oldPos);
+    return _getUIntCost(dis*2);
 }
+
+static const size_t getCoverDataCost(const TCover& curCover,const TCover& lastCover){
+    return  getOldPosCost(curCover.oldPos,lastCover)
+          + _getUIntCost(curCover.length)
+          + _getUIntCost(curCover.newPos-(lastCover.newPos+lastCover.length));
+}
+
 
 template <class TIndex>
 static void tm_search_cover(const adler_uint_t* blocksBase,size_t blocksSize,
@@ -429,34 +463,43 @@ static void tm_search_cover(const adler_uint_t* blocksBase,size_t blocksSize,
     const size_t kMatchBlockSize=newStream.kMatchBlockSize;
     TDigest_comp comp(blocksBase);
     TCover  lastCover={0,0,0};
-    //hpatch_StreamPos_t sumLen=0;
     while (true) {
-        if (filter.is_hit(newStream.rollDigest())){
-            std::pair<const TIndex*,const TIndex*>
-            range=std::equal_range(iblocks,iblocks_end,
-                                   TDigest_comp::TDigest(newStream.rollDigest()),comp);
-            if (range.first!=range.second){
-                const unsigned char* pnew=newStream.data();
-                if (is_same_data(pnew,kMatchBlockSize)){
-                    if (!newStream.skip_same(pnew[0])) break;//finish
-                    continue;
+        if (!filter.is_hit(newStream.rollDigest()))
+            { if (newStream.roll()) continue; else break; }//finish
+        std::pair<const TIndex*,const TIndex*>
+        range=std::equal_range(iblocks,iblocks_end,
+                               TDigest_comp::TDigest(newStream.rollDigest()),comp);
+        if (range.first==range.second)
+            { if (newStream.roll()) continue; else break; }//finish
+        
+        hpatch_StreamPos_t newPosBack=newStream.pos();
+        TCover  curCover;
+        if (getBestMatch(blocksBase,blocksSize,range.first,range.second,
+                         oldStream,newStream,lastCover,&curCover)){
+            hpatch_StreamPos_t linkOldPos=curCover.newPos+lastCover.oldPos-lastCover.newPos;
+            if (linkOldPos!=curCover.oldPos){//尝试共线;
+                newStream.TBlockStreamCache::resetPos(curCover.newPos);
+                hpatch_StreamPos_t matchedOldPos=linkOldPos;
+                hpatch_StreamPos_t curEqLen=getMatchLength(oldStream,newStream,
+                                                           matchedOldPos,kMatchBlockSize,lastCover);
+                size_t unlinkCost=getOldPosCost(curCover.oldPos,lastCover);
+                size_t unlinkCost_link=getOldPosCost(matchedOldPos,lastCover);
+                if ((curEqLen>0)&&(curEqLen+unlinkCost>=curCover.length+unlinkCost_link)){
+                    curCover.length=curEqLen;
+                    curCover.oldPos=matchedOldPos;
+                    curCover.newPos=curCover.newPos-(linkOldPos-matchedOldPos);
                 }
-                TCover  curCover;
-                if (getBestMatch(blocksBase,blocksSize,range.first,range.second,
-                                 oldStream,newStream,lastCover,&curCover)){
-                    //todo: + link cover
-                    out_covers->addCover(curCover);
-                    //sumLen+=curCover.length;
-                    lastCover=curCover;
-                    if (!newStream.resetPos(curCover.newPos+curCover.length)) break;//finish
-                    continue;
-                }//else roll
-            }//else roll
+            }
+            if (curCover.length>getCoverDataCost(curCover,lastCover)){
+                out_covers->addCover(curCover);
+                lastCover=curCover;
+                if (!newStream.resetPos(curCover.newPos+curCover.length)) break;//finish
+                continue; //matched
+            }
         }
-        if (!newStream.roll()) break;//finish
+        //match fail
+        if (!newStream.resetPos(newPosBack+1)) break;//finish
     }
-    //printf("%zu /%lld\n",out_covers->coverCount(),upperCount(newStream.streamSize(),kMatchBlockSize));
-    //printf("%lld / %lld\n",sumLen,newStream.streamSize());
 }
 
 void TDigestMatcher::search_cover(const hpatch_TStreamInput* newData,TCovers* out_covers){

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
@@ -425,7 +425,7 @@ template <class TIndex>
 static void tm_search_cover(const adler_uint_t* blocksBase,size_t blocksSize,
                             const TIndex* iblocks,const TIndex* iblocks_end,
                             TOldStreamCache& oldStream,TNewStreamCache& newStream,
-                            const TBloomFilter& filter,TCovers* out_covers) {
+                            const TBloomFilter<adler_uint_t>& filter,TCovers* out_covers) {
     const size_t kMatchBlockSize=newStream.kMatchBlockSize;
     TDigest_comp comp(blocksBase);
     TCover  lastCover={0,0,0};

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.h
@@ -49,7 +49,7 @@ private:
     bool                        m_isUseLargeSorted;
     size_t                      m_kMatchBlockSize;
     size_t                      m_newCacheSize;
-    TBloomFilter                m_filter;
+    TBloomFilter<adler_uint_t>  m_filter;
     
     void getDigests();
 };


### PR DESCRIPTION
大约多使用了50%的内存，在测试了5GB的文件diff时速度提升了约50%（在我的测试中可以控制到只需要10M级别的内存，50秒以内完成diff），而对于小文件500MB一下几乎没有提升；