### PR TITLE
support resave diffFile; optimize the speed of some test cases;

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2012-2017 housisong
+for HDiffPatch
+Copyright (c) 2012-2018 housisong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +20,55 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+------------------------------------------------------------------------------------------------------------------------------
+
+sais.hxx for sais-lite
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------------------------------------------------------
+
+for libdivsufsort
+Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a C\C++ library and command-line tools for binary data Diff & Patch.
 
 ---
 ## command line usage:
-**hdiffz** [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-o] **oldFile newFile outDiffFile**
+**hdiffz** [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-d] [-o] **oldFile newFile outDiffFile**
 **hdiffz** [-c-compressType[-compressLevel]] **diffFile outDiffFile**
 ```
 memory options:
@@ -20,6 +20,7 @@ memory options:
       requires O(oldFileSize*16/matchBlockSize+matchBlockSize*5) bytes of memory;
       matchBlockSize>=2, DEFAULT 128, recommended 32--16k 64k 1m etc...
 special options:
+  -d  Diff only, do't run patch check, DEFAULT run patch check;
   -c-compressType-compressLevel 
       set outDiffFile Compress type & level, DEFAULT uncompress;
       for resave diffFile,recompress diffFile to outDiffFile by new set;

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 **HDiffPatch**
 ================
-[![release](https://img.shields.io/badge/release-v2.4.3-blue.svg)](https://github.com/sisong/HDiffPatch/releases)  [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sisong/HDiffPatch/blob/master/LICENSE)  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/sisong/HDiffPatch/pulls)   
+[![release](https://img.shields.io/badge/release-v2.5.0-blue.svg)](https://github.com/sisong/HDiffPatch/releases)  [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sisong/HDiffPatch/blob/master/LICENSE)  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/sisong/HDiffPatch/pulls)   
 [![Build Status](https://travis-ci.org/sisong/HDiffPatch.svg?branch=master)](https://travis-ci.org/sisong/HDiffPatch) [![Build status](https://ci.appveyor.com/api/projects/status/t9ow8dft8lt898cv/branch/master?svg=true)](https://ci.appveyor.com/project/sisong/hdiffpatch/branch/master)   
 a C\C++ library and command-line tools for binary data Diff & Patch.   
 ( Jar or Zip file diff & patch? update Android Apk? try [ApkDiffPatch](https://github.com/sisong/ApkDiffPatch)! )
 
 ---
 ## command line usage:
-**hdiffz**  [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-o]  **oldFile newFile outDiffFile**
+**hdiffz** [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-o] **oldFile newFile outDiffFile**
+**hdiffz** [-c-compressType[-compressLevel]] **diffFile outDiffFile**
 ```
 memory options:
   -m-matchScore
       all file load into Memory, with matchScore; DEFAULT; best diffFileSize; 
-      requires (newFileSize+oldFileSize*5(or *9 when oldFileSize>=2GB))+O(1) bytes of memory;
+      requires (newFileSize+ oldFileSize*5(or *9 when oldFileSize>=2GB))+O(1) bytes of memory;
       matchScore>=0, DEFAULT 6, recommended bin: 0--4 text: 4--9 etc...
   -s-matchBlockSize
       all file load as Stream, with matchBlockSize; fast;
@@ -20,7 +21,8 @@ memory options:
       matchBlockSize>=2, DEFAULT 128, recommended 32--16k 64k 1m etc...
 special options:
   -c-compressType-compressLevel 
-      set diffFile Compress type & level, DEFAULT uncompress;
+      set outDiffFile Compress type & level, DEFAULT uncompress;
+      for resave diffFile,recompress diffFile to outDiffFile by new set;
       support compress type & level:
         (reference: https://github.com/sisong/lzbench/blob/master/lzbench171_sorted.md )
         -zlib[-{1..9}]              DEFAULT level 9

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ a C\C++ library and command-line tools for binary data Diff & Patch.
 
 ---
 ## command line usage:
-**hdiffz** [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-d] [-o] **oldFile newFile outDiffFile**
+**hdiffz** [-m[-matchScore]|-s[-matchBlockSize]] [-c-compressType[-compressLevel]] [-d] [-o] **oldFile newFile outDiffFile**   
 **hdiffz** [-c-compressType[-compressLevel]] **diffFile outDiffFile**
 ```
 memory options:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ memory options:
   -s-matchBlockSize
       all file load as Stream, with matchBlockSize; fast;
       requires O(oldFileSize*16/matchBlockSize+matchBlockSize*5) bytes of memory;
-      matchBlockSize>=2, DEFAULT 128, recommended 32--16k 64k 1m etc...
+      matchBlockSize>=2, DEFAULT 128, recommended 32,48,1k,64k,1m etc...
 special options:
   -d  Diff only, do't run patch check, DEFAULT run patch check;
   -c-compressType-compressLevel 

--- a/builds/xcode/hdiffz.xcodeproj/project.pbxproj
+++ b/builds/xcode/hdiffz.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		D690ABB61F2079E80089DC57 /* patch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = patch.h; sourceTree = "<group>"; };
 		D690AEFA1F2097C90089DC57 /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = usr/lib/libbz2.tbd; sourceTree = SDKROOT; };
 		D690AEFC1F2097D30089DC57 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		D69A372B21AED4B2000A0A93 /* patch_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = patch_private.h; sourceTree = "<group>"; };
 		D6DD68DE1F4015A900A1B22B /* digest_matcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = digest_matcher.cpp; sourceTree = "<group>"; };
 		D6DD68DF1F4015A900A1B22B /* digest_matcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = digest_matcher.h; sourceTree = "<group>"; };
 		D6DD68E11F40163200A1B22B /* adler_roll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adler_roll.h; sourceTree = "<group>"; };
@@ -181,6 +182,7 @@
 		D690ABB41F2079E80089DC57 /* HPatch */ = {
 			isa = PBXGroup;
 			children = (
+				D69A372B21AED4B2000A0A93 /* patch_private.h */,
 				D690ABB51F2079E80089DC57 /* patch.c */,
 				D690ABB61F2079E80089DC57 /* patch.h */,
 				D6E150941F21A95200C2AD3D /* patch_types.h */,

--- a/compress_plugin_demo.h
+++ b/compress_plugin_demo.h
@@ -400,13 +400,19 @@ static size_t _fun_compress_name(const hdiff_TCompress* compressPlugin, \
         unsigned char      properties_buf[LZMA_PROPS_SIZE+1];
         SizeT              properties_size=LZMA_PROPS_SIZE;
         SRes               ret;
+        uint32_t           dictSize=lzma_dictSize;
         if (!s) s=LzmaEnc_Create(&alloc);
         if (!s) _compress_error_return("LzmaEnc_Create()");
+        while ((dictSize >= in_data->streamSize*3)&&(dictSize>=4*1024*2))
+            dictSize>>=1;
         LzmaEncProps_Init(&props);
         props.level=lzma_compress_level;
-        props.dictSize=lzma_dictSize;
+        props.dictSize=dictSize;
         LzmaEncProps_Normalize(&props);
         if (SZ_OK!=LzmaEnc_SetProps(s,&props)) _compress_error_return("LzmaEnc_SetProps()");
+        if (IS_NOTICE_compress_canceled){
+            printf("  (add one lzma dictSize: %d)\n",props.dictSize);
+        }
         
         //save properties_size+properties
         assert(LZMA_PROPS_SIZE<256);

--- a/compress_plugin_demo.h
+++ b/compress_plugin_demo.h
@@ -59,9 +59,9 @@
     if ((result)==kCompressFailResult){      \
         if (outStream_isCanceled){    \
             if (IS_NOTICE_compress_canceled) \
-                printf("  NOTICE: " _at " is canceled, by out limit.\n"); \
+                printf("  (NOTICE: " _at " is canceled, by out limit.)\n"); \
         }else{ \
-            printf("  NOTICE: " _at " is canceled, %s ERROR!\n",_errAt); \
+            printf("  (NOTICE: " _at " is canceled, %s ERROR!)\n",_errAt); \
         } \
     }
 
@@ -411,7 +411,7 @@ static size_t _fun_compress_name(const hdiff_TCompress* compressPlugin, \
         LzmaEncProps_Normalize(&props);
         if (SZ_OK!=LzmaEnc_SetProps(s,&props)) _compress_error_return("LzmaEnc_SetProps()");
         if (IS_NOTICE_compress_canceled){
-            printf("  (add one lzma dictSize: %d)\n",props.dictSize);
+            printf("  (used one lzma dictSize: %d)\n",props.dictSize);
         }
         
         //save properties_size+properties

--- a/hdiffz.cpp
+++ b/hdiffz.cpp
@@ -90,7 +90,7 @@ static void printUsage(){
            "  -s-matchBlockSize\n"
            "      all file load as Stream, with matchBlockSize; fast;\n"
            "      requires O(oldFileSize*16/matchBlockSize+matchBlockSize*5) bytes of memory;\n"
-           "      matchBlockSize>=2, DEFAULT 128, recommended 32--16k 64k 1m etc...\n"
+           "      matchBlockSize>=2, DEFAULT 128, recommended 32,48,1k,64k,1m etc...\n"
            "special options:\n"
            "  -d  Diff only, do't run patch check, DEFAULT run patch check;\n"
            "  -c-compressType-compressLevel\n"
@@ -520,8 +520,8 @@ int hdiff(const char* oldFileName,const char* newFileName,const char* outDiffFil
         exitCode=hdiff_s(oldFileName,newFileName,outDiffFileName,isPatchCheck,
                          matchValue,streamCompressPlugin,decompressPlugin);
     }
-    double time1=clock_s();
-    std::cout<<"\nall   time: "<<(time1-time0)<<" s\n";
+    if (isPatchCheck)
+        std::cout<<"\nall   time: "<<(clock_s()-time0)<<" s\n";
     return exitCode;
 }
 

--- a/hdiffz.cpp
+++ b/hdiffz.cpp
@@ -581,7 +581,7 @@ static int hdiff_r(const char* diffFileName,const char* outDiffFileName,
     
     check(TFileStreamOutput_open(&diffData_out,outDiffFileName,-1),HDIFF_OPENWRITE_ERROR,"open out diffFile ERROR!");
     TFileStreamOutput_setRandomOut(&diffData_out,hpatch_TRUE);
-    std::cout<<"\ninDiffSize : "<<diffData_in.base.streamSize<<"\n";
+    std::cout<<"inDiffSize : "<<diffData_in.base.streamSize<<"\n";
     try{
         resave_compressed_diff(&diffData_in.base,decompressPlugin,&diffData_out.base,streamCompressPlugin);
         diffData_out.base.streamSize=diffData_out.out_length;

--- a/hpatchz.c
+++ b/hpatchz.c
@@ -49,13 +49,8 @@
 #   define _CompressPlugin_zlib
 #   define _CompressPlugin_bz2
 #   define _CompressPlugin_lzma
-#   define _CompressPlugin_lz4 // & _CompressPlugin_lz4hc
+#   define _CompressPlugin_lz4 // || _CompressPlugin_lz4hc
 #   define _CompressPlugin_zstd
-#endif
-#ifdef _CompressPlugin_lz4hc
-#   ifndef _CompressPlugin_lz4
-#       define _CompressPlugin_lz4
-#   endif
 #endif
 
 #include "decompress_plugin_demo.h"
@@ -269,7 +264,7 @@ int hpatch(const char* oldFileName,const char* diffFileName,const char* outNewFi
             if ((!decompressPlugin)&&lzmaDecompressPlugin.is_can_open(&lzmaDecompressPlugin,&diffInfo))
                 decompressPlugin=&lzmaDecompressPlugin;
 #endif
-#ifdef  _CompressPlugin_lz4
+#if (defined(_CompressPlugin_lz4) || (defined(_CompressPlugin_lz4hc)))
             if ((!decompressPlugin)&&lz4DecompressPlugin.is_can_open(&lz4DecompressPlugin,&diffInfo))
                 decompressPlugin=&lz4DecompressPlugin;
 #endif

--- a/libHDiffPatch/HDiff/diff.cpp
+++ b/libHDiffPatch/HDiff/diff.cpp
@@ -53,14 +53,14 @@ namespace{
     
     //覆盖线.
     struct TOldCover {
-        TInt   newPos;
         TInt   oldPos;
+        TInt   newPos;
         TInt   length;
-        inline TOldCover():newPos(0),oldPos(0),length(0) { }
-        inline TOldCover(TInt _newPos,TInt _oldPos,TInt _length)
-            :newPos(_newPos),oldPos(_oldPos),length(_length) { }
+        inline TOldCover():oldPos(0),newPos(0),length(0) { }
+        inline TOldCover(TInt _oldPos,TInt _newPos,TInt _length)
+            :oldPos(_oldPos),newPos(_newPos),length(_length) { }
         inline TOldCover(const TOldCover& cover)
-            :newPos(cover.newPos),oldPos(cover.oldPos),length(cover.length) { }
+            :oldPos(cover.oldPos),newPos(cover.newPos),length(cover.length) { }
         
         inline bool isCanLink(const TOldCover& next)const{//覆盖线是否可以连接.
             return isCollinear(next)&&(linkSpaceLength(next)<=kMaxLinkSpaceLength);
@@ -195,7 +195,7 @@ static void search_cover(TDiffData& diff,const TSuffixString& sstring){
     while (newPos<=maxSearchNewPos) {
         TInt matchOldPos=0;
         TInt matchEqLength=getBestMatch(&matchOldPos,sstring,diff.newData+newPos,diff.newData_end);
-        TOldCover matchCover(newPos,matchOldPos,matchEqLength);
+        TOldCover matchCover(matchOldPos,newPos,matchEqLength);
         if (matchEqLength-getCoverCtrlCost(matchCover,lastCover)<kMinMatchScore){
             ++newPos;//下一个需要匹配的字符串(逐位置匹配速度会比较慢).
             continue;

--- a/libHDiffPatch/HDiff/diff.cpp
+++ b/libHDiffPatch/HDiff/diff.cpp
@@ -789,9 +789,9 @@ void resave_compressed_diff(const hpatch_TStreamInput*  in_diff,
     outDiff.packUInt(head.rle_codeBuf_size);//rle_codeBuf size
     TPlaceholder compress_rle_codeBuf_sizePos=
         outDiff.packUInt_pos(compressPlugin?head.rle_codeBuf_size:0);//compress_rle_codeBuf size
-    outDiff.packUInt(head.compress_newDataDiff_size);
+    outDiff.packUInt(head.newDataDiff_size);
     TPlaceholder compress_newDataDiff_sizePos=
-        outDiff.packUInt_pos(compressPlugin?head.compress_newDataDiff_size:0);//compress_newDataDiff size
+        outDiff.packUInt_pos(compressPlugin?head.newDataDiff_size:0);//compress_newDataDiff size
     
     {//save covers
         TStreamClip clip(in_diff,head.headEndPos,head.coverEndPos,

--- a/libHDiffPatch/HDiff/diff.cpp
+++ b/libHDiffPatch/HDiff/diff.cpp
@@ -2,7 +2,7 @@
 //
 /*
  The MIT License (MIT)
- Copyright (c) 2012-2017 HouSisong
+ Copyright (c) 2012-2018 HouSisong
 
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
@@ -683,7 +683,7 @@ static void getCovers_stream(const hpatch_TStreamInput*  newData,
 
 static void stream_serialize(const hpatch_TStreamInput*  newData,
                              hpatch_StreamPos_t          oldDataSize,
-                             hpatch_TStreamOutput*       out_diff,
+                             const hpatch_TStreamOutput* out_diff,
                              hdiff_TStreamCompress* compressPlugin,
                              const TCovers& covers){
     
@@ -736,7 +736,7 @@ static void stream_serialize(const hpatch_TStreamInput*  newData,
 
 void create_compressed_diff_stream(const hpatch_TStreamInput*  newData,
                                    const hpatch_TStreamInput*  oldData,
-                                   hpatch_TStreamOutput*       out_diff,
+                                   const hpatch_TStreamOutput* out_diff,
                                    hdiff_TStreamCompress* compressPlugin,
                                    size_t kMatchBlockSize){
     const bool isSkipSameRange=(compressPlugin!=0);

--- a/libHDiffPatch/HDiff/diff.h
+++ b/libHDiffPatch/HDiff/diff.h
@@ -2,7 +2,7 @@
 //
 /*
  The MIT License (MIT)
- Copyright (c) 2012-2017 HouSisong
+ Copyright (c) 2012-2018 HouSisong
  
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
@@ -81,10 +81,11 @@ bool check_compressed_diff_stream(const hpatch_TStreamInput*  newData,
 //  NOTICE: out_diff->write()'s writeToPos may be back to update headData!
 //  throw std::runtime_error when I/O error,etc.
 static const size_t kMatchBlockSize_default = (1<<7);
-void create_compressed_diff_stream(const hpatch_TStreamInput* newData,
-                                   const hpatch_TStreamInput* oldData,
-                                   hpatch_TStreamOutput*      out_diff,
+void create_compressed_diff_stream(const hpatch_TStreamInput*  newData,
+                                   const hpatch_TStreamInput*  oldData,
+                                   const hpatch_TStreamOutput* out_diff,
                                    hdiff_TStreamCompress* compressPlugin=0,
                                    size_t kMatchBlockSize=kMatchBlockSize_default);
+
 
 #endif

--- a/libHDiffPatch/HDiff/diff.h
+++ b/libHDiffPatch/HDiff/diff.h
@@ -88,4 +88,12 @@ void create_compressed_diff_stream(const hpatch_TStreamInput*  newData,
                                    size_t kMatchBlockSize=kMatchBlockSize_default);
 
 
+//resave compressed_diff
+//  decompress int_diff and recompress to out_diff
+//  throw std::runtime_error when input file error or I/O error,etc.
+void resave_compressed_diff(const hpatch_TStreamInput*  in_diff,
+                            hpatch_TDecompress*         decompressPlugin,
+                            const hpatch_TStreamOutput* out_diff,
+                            hdiff_TStreamCompress*      compressPlugin);
+
 #endif

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/adler_roll.h
@@ -69,12 +69,12 @@ extern "C" {
 
 #define  __private_fast_adler_roll(uint_t,half_bit, \
                                   adler,blockSize,out_data,in_data){ \
-    uint32_t in_v=(uint32_t)in_data*in_data;    \
+    uint32_t in_v=((uint32_t)in_data)*in_data;  \
     uint32_t out_v=(uint32_t)out_data*out_data; \
     uint_t sum=adler>>half_bit;  \
     adler= adler + in_v - out_v; \
-    sum  = sum + adler - ADLER_INITIAL-(uint32_t)blockSize*out_v; \
-    return (adler&(((uint_t)1<<half_bit)-1)) | (sum<<half_bit);   \
+    sum  = sum + adler - ADLER_INITIAL-(uint32_t)(((uint32_t)blockSize)*out_v); \
+    return (adler&(((uint_t)1<<half_bit)-1)) | (sum<<half_bit); \
 }
 
 uint32_t adler32_append(uint32_t adler,const adler_data_t* pdata,size_t n);

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
@@ -38,6 +38,7 @@ static  const size_t kBestReadSize=1024*256; //for sequence read
 static  const size_t kMinReadSize=1024;      //for random first read speed
 static  const size_t kMinBackupReadSize=256;
 static  const size_t kMatchBlockSize_min=2;
+static  const size_t kMaxMatchRange=1024*64; //todo: optimize for delete this
 
 static inline adler_uint_t adler_start(const adler_data_t* pdata,size_t n){
     if (sizeof(adler_uint_t)>4) return (adler_uint_t)fast_adler64_start(pdata,n);
@@ -564,7 +565,8 @@ static void tm_search_cover(const adler_uint_t* blocksBase,size_t blocksSize,
         range=std::equal_range(iblocks,iblocks_end,digest_value,comp);
         if (range.first==range.second)
             { if (newStream.roll()) continue; else break; }//finish
-        //if (range.second-range.first>32) range.second=range.first+32;
+        if (range.second-range.first>kMaxMatchRange)
+            range.second=range.first+kMaxMatchRange;
         
         if (kIsSkipSameRange&&is_same_data(newStream.data(),newStream.kMatchBlockSize)){
             if (!newStream.skip_same(*newStream.data())) break;//finish

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
@@ -38,7 +38,8 @@ static  const size_t kBestReadSize=1024*256; //for sequence read
 static  const size_t kMinReadSize=1024;      //for random first read speed
 static  const size_t kMinBackupReadSize=256;
 static  const size_t kMatchBlockSize_min=2;
-static  const size_t kMaxMatchRange=1024*64; //todo: optimize for delete this
+static  const size_t kMaxMatchRange=1024*64;
+static  const size_t kMaxLinkIndexFindSize=64;
 
 static inline adler_uint_t adler_start(const adler_data_t* pdata,size_t n){
     if (sizeof(adler_uint_t)>4) return (adler_uint_t)fast_adler64_start(pdata,n);
@@ -129,6 +130,11 @@ static hpatch_StreamPos_t blockIndexToPos(size_t index,size_t kMatchBlockSize,
         pos=streamSize-kMatchBlockSize;
     return pos;
 }
+    
+static size_t posToBlockIndex(hpatch_StreamPos_t pos,size_t kMatchBlockSize){
+    return (size_t)( (pos+(kMatchBlockSize>>1))/kMatchBlockSize);
+}
+
 
 TDigestMatcher::~TDigestMatcher(){
     if (m_buf) free(m_buf);
@@ -415,24 +421,24 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
                          TOldStreamCache& oldStream,TNewStreamCache& newStream,
                          const TCover& lastCover,TCover* out_curCover){
     const size_t kMatchBlockSize=newStream.kMatchBlockSize;
-    TDigest_comp_i comp_i(blocksBase,blocksSize);
-    const size_t max_bdigests_n=upperCount(kMinTrustMatchedLength,kMatchBlockSize);
+    size_t max_digests_n=upperCount(kMinTrustMatchedLength,kMatchBlockSize);
+    size_t _data_max_digests_n=newStream.dataLength()/kMatchBlockSize;
+    if (max_digests_n>_data_max_digests_n) max_digests_n=_data_max_digests_n;
     
     const TIndex* best=0;
-    size_t bdigests_n=0;
+    size_t digests_eq_n=1;
     //缩小[left best right)范围,留下最多2个(因为签名匹配并不保证一定相等,2个的话应该就够了?);
     if (right-left>1){
         //寻找最长的签名匹配位置(也就是最有可能的最长匹配位置);
+        TDigest_comp_i comp_i(blocksBase,blocksSize);
         newStream.toBestDataLength();
-        size_t bmaxn=newStream.dataLength()/kMatchBlockSize-1;
-        if (bmaxn>max_bdigests_n) bmaxn=max_bdigests_n;
         const unsigned char* bdata=newStream.data()+kMatchBlockSize;
-        for (; (bdigests_n<bmaxn)&&(right-left>1);++bdigests_n,bdata+=kMatchBlockSize){
+        for (; (digests_eq_n<max_digests_n)&&(right-left>1);++digests_eq_n,bdata+=kMatchBlockSize){
             adler_uint_t digest=adler_start(bdata,kMatchBlockSize);
             typename TDigest_comp::TDigest digest_value(digest);
-            comp_i.i=bdigests_n+1;
-            std::pair<const TIndex*,const TIndex*>
-            i_range=std::equal_range(left,right,digest_value,comp_i);
+            comp_i.i=digests_eq_n;
+            std::pair<const TIndex*,const TIndex*> i_range=
+                std::equal_range(left,right,digest_value,comp_i);
             size_t rn=i_range.second-i_range.first;
             if (rn==0){
                 break;
@@ -444,32 +450,70 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
                 right=i_range.second;
             }
         }
+    }else{
+        best=left;
     }
+    //best==0 说明有>2个位置都是最好位置,还需要继续寻找;
+    
+    hpatch_StreamPos_t linkOldPos=newStream.pos()+lastCover.oldPos-lastCover.newPos;
+    TIndex linkIndex=(TIndex)posToBlockIndex(linkOldPos,kMatchBlockSize);
+    //找到lastCover附近的位置当作比较好的best默认值,以利于link或压缩;
     if (best==0){
-        //找到lastCover附近的位置当作比较好的best默认值,以利于link;
-        hpatch_StreamPos_t linkOldPos=newStream.pos()+lastCover.oldPos-lastCover.newPos;
-        hpatch_StreamPos_t _best_distance=(hpatch_StreamPos_t)1<<30;
-        for (const TIndex* it=left;it<right; ++it) {
-            hpatch_StreamPos_t oldPos=(*it)*kMatchBlockSize;
-            hpatch_StreamPos_t distance=(oldPos<linkOldPos)?(linkOldPos-oldPos):(oldPos-linkOldPos);
-            if (distance<_best_distance){
+        TIndex_comp comp(blocksBase,blocksSize,max_digests_n);
+        size_t findCount=(right-left)*2+1;
+        if (findCount>kMaxLinkIndexFindSize) findCount=kMaxLinkIndexFindSize;
+        for (TIndex inc=1;(inc<=findCount);++inc) { //linkIndex附近找;
+            TIndex fi;  TIndex s=(inc>>1);
+            if (inc&1){
+                if (linkIndex<s) continue;
+                fi=linkIndex-s;
+            }else{
+                if (linkIndex+s>=blocksSize) continue;
+                fi=linkIndex+s;
+            }
+            std::pair<const TIndex*,const TIndex*> i_range=std::equal_range(left,right,fi,comp);
+            if (i_range.first!=i_range.second){
+                best=i_range.first+(i_range.second-i_range.first)/2;
+                for (const TIndex* ci=best;ci<i_range.second; ++ci) {
+                    if (*ci==fi) { best=ci; break;  } //找到;
+                }
+                break;
+            }
+        }
+    }
+    if(best==0){ //继续找;
+        best=left+(right-left)/2;
+        hpatch_StreamPos_t _best_distance=~(hpatch_StreamPos_t)0;
+        const TIndex* end=(right-left<=kMaxMatchRange)?right:(left+kMaxMatchRange);
+        for (const TIndex* it=left;it<end; ++it) {
+            hpatch_StreamPos_t oldIndex=(*it);
+            hpatch_StreamPos_t distance=(oldIndex<linkIndex)?(linkIndex-oldIndex):(oldIndex-linkIndex);
+            if (distance<_best_distance){ //找最近;
                 best=it;
                 _best_distance=distance;
             }
         }
     }
-    //继续缩小范围;
-    if (best>left)
-        right=0;
-    else
-        left=0;
-
+    
     const hpatch_StreamPos_t newPos=newStream.pos();
     bool isMatched=false;
     hpatch_StreamPos_t  bestLen=0;
-    for (const TIndex* cur_pi=best; cur_pi!=0; ) {
-        const hpatch_StreamPos_t oldPos=blockIndexToPos(*cur_pi,kMatchBlockSize,
-                                                        oldStream.streamSize());
+    const size_t kMaxFindCount=5; //周围距离2;
+    size_t findCount=(right-left)*2+1;
+    if (findCount>kMaxFindCount) findCount=kMaxFindCount;
+    for (size_t inc=1;(inc<=findCount);++inc) { //best附近找;
+        const TIndex* fi;  size_t s=(inc>>1);
+        if (inc&1){
+            if (best<left+s) continue;
+            fi=best-s;
+        }else{
+            if (best+s>=right) continue;
+            fi=best+s;
+        }
+        if (inc>1)
+            newStream.TBlockStreamCache::resetPos(newPos);
+        
+        hpatch_StreamPos_t oldPos=blockIndexToPos(*fi,kMatchBlockSize,oldStream.streamSize());
         hpatch_StreamPos_t matchedOldPos=oldPos;
         hpatch_StreamPos_t curEqLen=getMatchLength(oldStream,newStream,
                                                    &matchedOldPos,kMatchBlockSize,lastCover);
@@ -479,21 +523,9 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
             out_curCover->length=curEqLen;
             out_curCover->oldPos=matchedOldPos;
             out_curCover->newPos=newPos-(oldPos-matchedOldPos);
-            if (curEqLen>=bdigests_n*kMatchBlockSize)
+            if (curEqLen>=digests_eq_n*kMatchBlockSize)
                 break;//matched best
         }
-        //next cur_pi
-        if (left!=0){
-            cur_pi=best-1;
-            left=0;
-        }else if (best+1<right){
-            cur_pi=best+1;
-            right=0;
-        }else{
-            cur_pi=0;
-        }
-        if (cur_pi)
-            newStream.TBlockStreamCache::resetPos(newPos);
     }
     return isMatched;
 }
@@ -565,8 +597,6 @@ static void tm_search_cover(const adler_uint_t* blocksBase,size_t blocksSize,
         range=std::equal_range(iblocks,iblocks_end,digest_value,comp);
         if (range.first==range.second)
             { if (newStream.roll()) continue; else break; }//finish
-        if (range.second-range.first>kMaxMatchRange)
-            range.second=range.first+kMaxMatchRange;
         
         if (kIsSkipSameRange&&is_same_data(newStream.data(),newStream.kMatchBlockSize)){
             if (!newStream.skip_same(*newStream.data())) break;//finish

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/digest_matcher.cpp
@@ -484,7 +484,7 @@ static bool getBestMatch(const adler_uint_t* blocksBase,size_t blocksSize,
     if(best==0){ //继续找;
         best=left+(right-left)/2;
         hpatch_StreamPos_t _best_distance=~(hpatch_StreamPos_t)0;
-        const TIndex* end=(right-left<=kMaxMatchRange)?right:(left+kMaxMatchRange);
+        const TIndex* end=(left+kMaxMatchRange>=right)?right:(left+kMaxMatchRange);
         for (const TIndex* it=left;it<end; ++it) {
             hpatch_StreamPos_t oldIndex=(*it);
             hpatch_StreamPos_t distance=(oldIndex<linkIndex)?(linkIndex-oldIndex):(oldIndex-linkIndex);

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
@@ -241,7 +241,7 @@ hpatch_StreamPos_t TNewDataDiffStream::getDataSize(const TCovers& covers,hpatch_
 }
 
 
-TDiffStream::TDiffStream(hpatch_TStreamOutput* _out_diff,const TCovers& _covers)
+TDiffStream::TDiffStream(const hpatch_TStreamOutput* _out_diff,const TCovers& _covers)
 :out_diff(_out_diff),covers(_covers),writePos(0),_temp_buf(0){
     _temp_buf=(unsigned char*)malloc(kBufSize);
     if (!_temp_buf) throw std::runtime_error("TDiffStream::TDiffStream() malloc() error!");

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
@@ -323,29 +323,61 @@ TStreamClip::TStreamClip(const hpatch_TStreamInput* stream,
                          hpatch_StreamPos_t clipBeginPos,hpatch_StreamPos_t clipEndPos,
                          hpatch_TDecompress* decompressPlugin,hpatch_StreamPos_t uncompressSize)
 :_src(stream),_src_begin(clipBeginPos),_src_end(clipEndPos),
-    _decompressPlugin(decompressPlugin),_read_uncompress_pos(0){
+_decompressPlugin(decompressPlugin),_read_uncompress_pos(0),_decompressHandle(0){
     assert(clipBeginPos<=clipEndPos);
     assert(clipEndPos<=stream->streamSize);
     this->streamHandle=this;
     this->streamSize=uncompressSize;
     this->read=_clip_read;
+    
+    if (decompressPlugin)
+        openDecompressHandle();
+}
+    
+TStreamClip::~TStreamClip(){
+    closeDecompressHandle();
+}
+    
+    
+void TStreamClip::closeDecompressHandle(){
+    hpatch_decompressHandle handle=_decompressHandle;
+    _decompressHandle=0;
+    if (handle)
+        _decompressPlugin->close(_decompressPlugin,handle);
+}
+void TStreamClip::openDecompressHandle(){
+    assert(_decompressHandle==0);
+    assert(_decompressPlugin!=0);
+    _decompressHandle=_decompressPlugin->open(_decompressPlugin,this->streamSize,_src,_src_begin,_src_end);
+    check(_decompressHandle!=0);
 }
 
 long TStreamClip::_clip_read(hpatch_TStreamInputHandle streamHandle,
                              const hpatch_StreamPos_t readFromPos,
                              unsigned char* out_data,unsigned char* out_data_end){
     TStreamClip* self=(TStreamClip*)streamHandle;
-    assert(readFromPos==self->_read_uncompress_pos);
     assert(out_data<out_data_end);
+    if (readFromPos!=self->_read_uncompress_pos){
+        if (readFromPos==0){//reset
+            self->closeDecompressHandle();
+            if (self->_decompressPlugin)
+                self->openDecompressHandle();
+            self->_read_uncompress_pos=0;
+        }else{
+            assert(false); //not support
+        }
+    }
     size_t readLen=out_data_end-out_data;
     assert(readFromPos+readLen <= self->streamSize);
     self->_read_uncompress_pos+=readLen;
     
-    if (!self->_decompressPlugin)
-        return self->_src->read(self->_src->streamHandle,self->_src_begin+readFromPos,out_data,out_data_end);
-    
-    //todo:
-    return 0;
+    if (self->_decompressPlugin){
+        return self->_decompressPlugin->decompress_part(self->_decompressPlugin,
+                                                        self->_decompressHandle,out_data,out_data_end);
+    }else{
+        return self->_src->read(self->_src->streamHandle,
+                                self->_src_begin+readFromPos,out_data,out_data_end);
+    }
 }
     
 }//namespace hdiff_private

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
@@ -93,7 +93,7 @@ struct TPlaceholder{
 };
 
 struct TDiffStream{
-    explicit TDiffStream(hpatch_TStreamOutput* _out_diff,const TCovers& _covers);
+    explicit TDiffStream(const hpatch_TStreamOutput* _out_diff,const TCovers& _covers);
     ~TDiffStream();
     
     void pushBack(const unsigned char* src,size_t n);

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
@@ -126,12 +126,16 @@ public:
     explicit TStreamClip(const hpatch_TStreamInput* stream,
                          hpatch_StreamPos_t clipBeginPos,hpatch_StreamPos_t clipEndPos,
                          hpatch_TDecompress* decompressPlugin,hpatch_StreamPos_t uncompressSize);
+    ~TStreamClip();
 private:
     const hpatch_TStreamInput*  _src;
     const hpatch_StreamPos_t    _src_begin;
     const hpatch_StreamPos_t    _src_end;
     hpatch_TDecompress*         _decompressPlugin;
     hpatch_StreamPos_t          _read_uncompress_pos;
+    hpatch_decompressHandle     _decompressHandle;
+    void closeDecompressHandle();
+    void openDecompressHandle();
     static long _clip_read(hpatch_TStreamInputHandle streamHandle,
                            const hpatch_StreamPos_t readFromPos,
                            unsigned char* out_data,unsigned char* out_data_end);

--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.h
@@ -93,7 +93,7 @@ struct TPlaceholder{
 };
 
 struct TDiffStream{
-    explicit TDiffStream(const hpatch_TStreamOutput* _out_diff,const TCovers& _covers);
+    explicit TDiffStream(const hpatch_TStreamOutput* _out_diff);
     ~TDiffStream();
     
     void pushBack(const unsigned char* src,size_t n);
@@ -110,7 +110,6 @@ struct TDiffStream{
                     const TPlaceholder&          update_compress_sizePos);
 private:
     const hpatch_TStreamOutput*  out_diff;
-    const  TCovers&        covers;
     hpatch_StreamPos_t     writePos;
     enum{ kBufSize=1024*128 };
     unsigned char*         _temp_buf;
@@ -119,6 +118,23 @@ private:
     
     //stream->read can return currently readed data size,return <0 error
     void _pushStream(const hpatch_TStreamInput* stream);
+};
+
+
+class TStreamClip:public hpatch_TStreamInput{
+public:
+    explicit TStreamClip(const hpatch_TStreamInput* stream,
+                         hpatch_StreamPos_t clipBeginPos,hpatch_StreamPos_t clipEndPos,
+                         hpatch_TDecompress* decompressPlugin,hpatch_StreamPos_t uncompressSize);
+private:
+    const hpatch_TStreamInput*  _src;
+    const hpatch_StreamPos_t    _src_begin;
+    const hpatch_StreamPos_t    _src_end;
+    hpatch_TDecompress*         _decompressPlugin;
+    hpatch_StreamPos_t          _read_uncompress_pos;
+    static long _clip_read(hpatch_TStreamInputHandle streamHandle,
+                           const hpatch_StreamPos_t readFromPos,
+                           unsigned char* out_data,unsigned char* out_data_end);
 };
 
 }//namespace hdiff_private

--- a/libHDiffPatch/HPatch/patch.c
+++ b/libHDiffPatch/HPatch/patch.c
@@ -2,7 +2,7 @@
 //
 /*
  The MIT License (MIT)
- Copyright (c) 2012-2017 HouSisong
+ Copyright (c) 2012-2018 HouSisong
 
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation

--- a/libHDiffPatch/HPatch/patch.c
+++ b/libHDiffPatch/HPatch/patch.c
@@ -30,6 +30,7 @@
 #ifdef _IS_NEED_CACHE_OLD_BY_COVERS
 #   include <stdlib.h> //qsort
 #endif
+#include "patch_private.h"
 
 //__RUN_MEM_SAFE_CHECK用来启动内存访问越界检查,用以防御可能被意外或故意损坏的数据.
 #define __RUN_MEM_SAFE_CHECK
@@ -912,30 +913,12 @@ static hpatch_BOOL _patch_stream_with_cache(const struct hpatch_TStreamOutput* o
 
 #define kVersionTypeLen 8
 
-typedef struct _THDiffzHead{
-    TUInt coverCount;
-    
-    TUInt cover_buf_size;
-    TUInt compress_cover_buf_size;
-    TUInt rle_ctrlBuf_size;
-    TUInt compress_rle_ctrlBuf_size;
-    TUInt rle_codeBuf_size;
-    TUInt compress_rle_codeBuf_size;
-    TUInt newDataDiff_size;
-    TUInt compress_newDataDiff_size;
-    
-    TUInt headEndPos;
-    TUInt coverEndPos;
-} _THDiffzHead;
-
-
 //assert(hpatch_kStreamCacheSize>=hpatch_kMaxCompressTypeLength+1);
 struct __private_hpatch_check_kMaxCompressTypeLength {
     char _[(hpatch_kStreamCacheSize>=(hpatch_kMaxCompressTypeLength+1))?1:-1];};
 
-static hpatch_BOOL read_diffz_head(hpatch_compressedDiffInfo* out_diffInfo,
-                                   _THDiffzHead* out_head,
-                                   const hpatch_TStreamInput* compressedDiff){
+hpatch_BOOL read_diffz_head(hpatch_compressedDiffInfo* out_diffInfo,_THDiffzHead* out_head,
+                            const hpatch_TStreamInput* compressedDiff){
     TStreamClip  _diffHeadClip;
     TStreamClip* diffHeadClip=&_diffHeadClip;
     TByte       temp_cache[hpatch_kStreamCacheSize];

--- a/libHDiffPatch/HPatch/patch.h
+++ b/libHDiffPatch/HPatch/patch.h
@@ -2,7 +2,7 @@
 //
 /*
  The MIT License (MIT)
- Copyright (c) 2012-2017 HouSisong
+ Copyright (c) 2012-2018 HouSisong
  
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation

--- a/libHDiffPatch/HPatch/patch_private.h
+++ b/libHDiffPatch/HPatch/patch_private.h
@@ -1,0 +1,61 @@
+//  patch_private.h
+//
+/*
+ The MIT License (MIT)
+ Copyright (c) 2012-2018 HouSisong
+ 
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+ 
+ The above copyright notice and this permission notice shall be
+ included in all copies of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef HPatch_patch_private_h
+#define HPatch_patch_private_h
+
+#include "patch_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct _THDiffzHead{
+    hpatch_StreamPos_t coverCount;
+    
+    hpatch_StreamPos_t cover_buf_size;
+    hpatch_StreamPos_t compress_cover_buf_size;
+    hpatch_StreamPos_t rle_ctrlBuf_size;
+    hpatch_StreamPos_t compress_rle_ctrlBuf_size;
+    hpatch_StreamPos_t rle_codeBuf_size;
+    hpatch_StreamPos_t compress_rle_codeBuf_size;
+    hpatch_StreamPos_t newDataDiff_size;
+    hpatch_StreamPos_t compress_newDataDiff_size;
+    
+    hpatch_StreamPos_t headEndPos;
+    hpatch_StreamPos_t coverEndPos;
+} _THDiffzHead;
+    
+hpatch_BOOL read_diffz_head(hpatch_compressedDiffInfo* out_diffInfo,_THDiffzHead* out_head,
+                            const hpatch_TStreamInput* compressedDiff);
+    
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
diffFile can resave by command line: hdiffz [-c-compressType[-compressLevel]] diffFile outDiffFile      
can close patch check when diff : hdiffz -d ...   
optimize unnecessary LZMA compression dictSize size  (related #65 )      
optimize the speed of some test cases (too much same data!)   
now , allow options "-*" can be set at any parameter position; such as: hdiffz old new diff -m -c-lzma-9-128m   

close #85    
close #86 
