### PR TITLE
fix include

### DIFF
--- a/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
+++ b/libHDiffPatch/HDiff/private_diff/limit_mem_diff/stream_serialize.cpp
@@ -28,6 +28,7 @@
 #include <string.h> //memcpy
 #include <stdexcept> //std::runtime_error
 #include "../../diff.h" //for stream type
+#include <algorithm>
 
 #define checki(value,info) { if (!(value)) { throw std::runtime_error(info); } }
 #define check(value) checki(value,"check "#value" error!")


### PR DESCRIPTION
Fix for unrecognized std::min due to missing include of algorithm.